### PR TITLE
Organiza download e posiciona conteúdo no canto superior

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,24 +239,35 @@
                 borderRadius: '24px',
                 boxShadow: '0 4px 6px rgba(0,0,0,0.1)',
                 overflow: 'hidden',
-                display: 'flex',
-                flexDirection: 'column',
+                position: 'relative',
+                height: '360px',
                 fontFamily: "'Poppins', sans-serif",
                 color: '#111'
             }}>
-                <div style={{ backgroundColor: '#f9fafb', padding: '1rem', height: '160px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <div style={{ backgroundColor: '#f9fafb', width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                     <img src={product.imageUrl} alt={product.name} style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }} />
                 </div>
-                <div style={{ padding: '1rem', flexGrow: 1, display: 'flex', flexDirection: 'column' }}>
-                    <h3 style={{ fontWeight: '700', fontSize: '1.125rem', marginBottom: '0.75rem', color: 'var(--brand-green)' }}>{product.name}</h3>
-                    <div style={{ marginTop: 'auto', display: 'flex', flexDirection: 'column', gap: '0.5rem', fontSize: '0.875rem' }}>
-                        {(product.details || []).map((detail, index) => (
-                            <div key={index} style={{ borderLeft: '4px solid #e5e7eb', paddingLeft: '0.75rem' }}>
-                                <div style={{ fontWeight: '600', color: '#4b5563' }}>{detail.flavor}</div>
-                                <div style={{ fontWeight: '700', color: '#1f2937' }}>Cód: {detail.code}</div>
-                            </div>
-                        ))}
-                    </div>
+                <div style={{
+                    position: 'absolute',
+                    top: '16px',
+                    right: '16px',
+                    textAlign: 'right',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'flex-end',
+                    gap: '0.5rem',
+                    backgroundColor: 'rgba(255,255,255,0.9)',
+                    padding: '0.5rem',
+                    borderRadius: '12px',
+                    fontSize: '0.875rem'
+                }}>
+                    <h3 style={{ fontWeight: '700', fontSize: '1.125rem', color: 'var(--brand-green)' }}>{product.name}</h3>
+                    {(product.details || []).map((detail, index) => (
+                        <div key={index} style={{ borderLeft: '4px solid #e5e7eb', paddingLeft: '0.75rem' }}>
+                            <div style={{ fontWeight: '600', color: '#4b5563' }}>{detail.flavor}</div>
+                            <div style={{ fontWeight: '700', color: '#1f2937' }}>Cód: {detail.code}</div>
+                        </div>
+                    ))}
                 </div>
             </div>
         );
@@ -264,20 +275,20 @@
         const PrintableCatalog = ({ groupedProducts }) => (
             <div id="printable-catalog" style={{ display: 'none' }}>
                 {groupedProducts.map(group => (
-                    <div 
+                    <div
                         key={group.category}
                         className="printable-category-section"
                         data-category-name={group.category}
                         style={{
                             width: '1080px', /* Status width */
                             padding: '48px',
+                            paddingTop: '120px',
                             backgroundColor: '#f3f4f6', /* Light gray background */
                             fontFamily: "'Poppins', sans-serif",
+                            position: 'relative'
                         }}
                     >
-                        <div style={{ textAlign: 'center', marginBottom: '32px' }}>
-                            <h2 style={{ fontSize: '48px', fontWeight: '700', color: 'var(--brand-green)' }}>{group.category}</h2>
-                        </div>
+                        <h2 style={{ position: 'absolute', top: '48px', right: '48px', fontSize: '48px', fontWeight: '700', color: 'var(--brand-green)' }}>{group.category}</h2>
                         <div style={{
                             display: 'grid',
                             gridTemplateColumns: 'repeat(3, 1fr)',
@@ -285,7 +296,7 @@
                         }}>
                             {group.products.map(p => <PrintableProductCard key={p.id} product={p} />)}
                         </div>
-                         <div style={{ textAlign: 'center', marginTop: '48px' }}>
+                        <div style={{ textAlign: 'center', marginTop: '48px' }}>
                             <span style={{ fontSize: '36px', fontWeight: '700', color: 'var(--brand-green)' }}>Igor</span>
                             <span style={{ fontSize: '36px', fontWeight: '700', color: 'var(--brand-red)' }}>Valen</span>
                             <p style={{ fontSize: '24px', color: '#374151' }}>Distribuidora</p>
@@ -309,12 +320,11 @@
 
                 printableElement.style.display = 'block';
 
-                const categorySections = printableElement.getElementsByClassName('printable-category-section');
+                const categorySections = Array.from(printableElement.getElementsByClassName('printable-category-section'));
 
-                for (let i = 0; i < categorySections.length; i++) {
-                    const section = categorySections[i];
+                for (const section of categorySections) {
                     const categoryName = section.dataset.categoryName || 'categoria';
-                    
+
                     await new Promise(resolve => setTimeout(resolve, 100));
 
                     const canvas = await html2canvas(section, {
@@ -322,15 +332,15 @@
                         backgroundColor: '#f3f4f6',
                         useCORS: true
                     });
-                    
-                    const image = canvas.toDataURL("image/png", 1.0);
-                    
+
+                    const blob = await new Promise(resolve => canvas.toBlob(resolve, 'image/png', 1.0));
                     const link = document.createElement('a');
                     link.download = `catalogo-${categoryName.replace(/ /g, '_')}.png`;
-                    link.href = image;
+                    link.href = URL.createObjectURL(blob);
                     document.body.appendChild(link);
                     link.click();
                     document.body.removeChild(link);
+                    URL.revokeObjectURL(link.href);
                 }
 
                 printableElement.style.display = 'none';
@@ -424,17 +434,17 @@
                         </p>
                         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
                             <div className="bg-white p-6 rounded-3xl shadow-lg text-center">
-                                <img src="https://group-ism.com/br/wp-content/uploads/2023/07/ism-9001.png" alt="[Imagem do selo ISO 9001]" className="h-28 mx-auto mb-4 rounded-xl"/>
+                                <img src="https://group-ism.com/br/wp-content/uploads/2023/07/ism-9001.png" alt="[Imagem do selo ISO 9001]" className="w-28 h-28 mx-auto mb-4 rounded-full object-cover"/>
                                 <h3 className="font-bold text-lg text-gray-800">ISO 9001</h3>
-                                <p className="text-sm text-gray-600">Norma internacional centrada na gestão da qualidade de um sistema efetivo, e melhoria da qualidade dos produtos e serviços.</p>
+                <p className="text-sm text-gray-600">Norma internacional centrada na gestão da qualidade de um sistema efetivo, e melhoria da qualidade dos produtos e serviços.</p>
                             </div>
                             <div className="bg-white p-6 rounded-3xl shadow-lg text-center">
-                                <img src="https://group-ism.com/br/wp-content/uploads/2023/07/ism-14001.png" alt="[Imagem do selo ISO 14001]" className="h-28 mx-auto mb-4 rounded-xl"/>
+                                <img src="https://group-ism.com/br/wp-content/uploads/2023/07/ism-14001.png" alt="[Imagem do selo ISO 14001]" className="w-28 h-28 mx-auto mb-4 rounded-full object-cover"/>
                                 <h3 className="font-bold text-lg text-gray-800">ISO 14001</h3>
                                 <p className="text-sm text-gray-600">Norma internacional focada no compromisso da organização com a proteção do meio ambiente por meio da gestão dos riscos ambientais.</p>
                             </div>
                             <div className="bg-white p-6 rounded-3xl shadow-lg text-center">
-                                <img src="https://group-ism.com/br/wp-content/uploads/2023/07/ism-45001-ES.png" alt="[Imagem do selo ISO 45001]" className="h-28 mx-auto mb-4 rounded-xl"/>
+                                <img src="https://group-ism.com/br/wp-content/uploads/2023/07/ism-45001-ES.png" alt="[Imagem do selo ISO 45001]" className="w-28 h-28 mx-auto mb-4 rounded-full object-cover"/>
                                 <h3 className="font-bold text-lg text-gray-800">ISO 45001</h3>
                                 <p className="text-sm text-gray-600">Norma internacional que proporciona as condições de trabalho seguras e saudáveis para prevenir os danos e deterioração da saúde.</p>
                             </div>


### PR DESCRIPTION
## Summary
- Reorganize printable catalog so category headers and product details sit at the upper-right for status-friendly images
- Generate category images sequentially via html2canvas blobs for smoother multi-photo downloads
- Ensure ISO certification images render as perfect circles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fc4597888333bf63e08709df3c4a