### PR TITLE
Organiza download individual dos produtos em imagens

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,7 +185,9 @@
             categoriesOrder: ['Bebidas não alcoólicas', 'Bebidas alcoólicas', 'Bomboneire', 'Cigarro', 'Utilidades'],
         };
 
-        const api = {
+        // Tornamos o stub acessível globalmente para que outras tags <script>
+        // possam utilizá-lo sem gerar ReferenceError e quebrar o app.
+        window.api = {
             getCatalog: async (q) => {
                 console.log("API STUB: getCatalog", {q});
                 await new Promise(res => setTimeout(res, 200));
@@ -233,64 +235,76 @@
         };
 
         // --- Helper Components for Image Generation ---
-        const PrintableProductCard = ({ product }) => (
-            <div style={{
-                backgroundColor: 'white',
-                borderRadius: '24px',
-                boxShadow: '0 4px 6px rgba(0,0,0,0.1)',
-                overflow: 'hidden',
-                display: 'flex',
-                flexDirection: 'column',
-                fontFamily: "'Poppins', sans-serif",
-                color: '#111'
-            }}>
-                <div style={{ backgroundColor: '#f9fafb', padding: '1rem', height: '160px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                    <img src={product.imageUrl} alt={product.name} style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }} />
+        const PrintableProductCard = ({ product, category }) => (
+            <div
+                className="printable-product"
+                data-product-name={product.name}
+                data-category-name={category}
+                style={{
+                    width: '1080px',
+                    height: '1920px',
+                    padding: '48px',
+                    boxSizing: 'border-box',
+                    backgroundColor: '#f3f4f6',
+                    fontFamily: "'Poppins', sans-serif",
+                    position: 'relative',
+                    display: 'flex',
+                    justifyContent: 'center',
+                    alignItems: 'center'
+                }}
+            >
+                <img
+                    src={product.imageUrl}
+                    alt={product.name}
+                    crossOrigin="anonymous"
+                    style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }}
+                />
+                <div
+                    style={{
+                        position: 'absolute',
+                        top: '48px',
+                        right: '48px',
+                        textAlign: 'right',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'flex-end',
+                        gap: '0.5rem',
+                        backgroundColor: 'rgba(255,255,255,0.9)',
+                        padding: '0.75rem',
+                        borderRadius: '12px'
+                    }}
+                >
+                    <h2 style={{ fontSize: '2.25rem', fontWeight: '700', color: 'var(--brand-green)' }}>{category}</h2>
+                    <h3 style={{ fontWeight: '700', fontSize: '1.5rem', color: 'var(--brand-green)' }}>{product.name}</h3>
+                    {(product.details || []).map((detail, index) => (
+                        <div key={index} style={{ borderLeft: '4px solid #e5e7eb', paddingLeft: '0.75rem' }}>
+                            <div style={{ fontWeight: '600', color: '#4b5563' }}>{detail.flavor}</div>
+                            <div style={{ fontWeight: '700', color: '#1f2937' }}>Cód: {detail.code}</div>
+                        </div>
+                    ))}
                 </div>
-                <div style={{ padding: '1rem', flexGrow: 1, display: 'flex', flexDirection: 'column' }}>
-                    <h3 style={{ fontWeight: '700', fontSize: '1.125rem', marginBottom: '0.75rem', color: 'var(--brand-green)' }}>{product.name}</h3>
-                    <div style={{ marginTop: 'auto', display: 'flex', flexDirection: 'column', gap: '0.5rem', fontSize: '0.875rem' }}>
-                        {(product.details || []).map((detail, index) => (
-                            <div key={index} style={{ borderLeft: '4px solid #e5e7eb', paddingLeft: '0.75rem' }}>
-                                <div style={{ fontWeight: '600', color: '#4b5563' }}>{detail.flavor}</div>
-                                <div style={{ fontWeight: '700', color: '#1f2937' }}>Cód: {detail.code}</div>
-                            </div>
-                        ))}
-                    </div>
+                <div
+                    style={{
+                        position: 'absolute',
+                        bottom: '48px',
+                        left: 0,
+                        right: 0,
+                        textAlign: 'center'
+                    }}
+                >
+                    <span style={{ fontSize: '36px', fontWeight: '700', color: 'var(--brand-green)' }}>Igor</span>
+                    <span style={{ fontSize: '36px', fontWeight: '700', color: 'var(--brand-red)' }}>Valen</span>
+                    <p style={{ fontSize: '24px', color: '#374151' }}>Distribuidora</p>
                 </div>
             </div>
         );
 
         const PrintableCatalog = ({ groupedProducts }) => (
             <div id="printable-catalog" style={{ display: 'none' }}>
-                {groupedProducts.map(group => (
-                    <div 
-                        key={group.category}
-                        className="printable-category-section"
-                        data-category-name={group.category}
-                        style={{
-                            width: '1080px', /* Status width */
-                            padding: '48px',
-                            backgroundColor: '#f3f4f6', /* Light gray background */
-                            fontFamily: "'Poppins', sans-serif",
-                        }}
-                    >
-                        <div style={{ textAlign: 'center', marginBottom: '32px' }}>
-                            <h2 style={{ fontSize: '48px', fontWeight: '700', color: 'var(--brand-green)' }}>{group.category}</h2>
-                        </div>
-                        <div style={{
-                            display: 'grid',
-                            gridTemplateColumns: 'repeat(3, 1fr)',
-                            gap: '24px'
-                        }}>
-                            {group.products.map(p => <PrintableProductCard key={p.id} product={p} />)}
-                        </div>
-                         <div style={{ textAlign: 'center', marginTop: '48px' }}>
-                            <span style={{ fontSize: '36px', fontWeight: '700', color: 'var(--brand-green)' }}>Igor</span>
-                            <span style={{ fontSize: '36px', fontWeight: '700', color: 'var(--brand-red)' }}>Valen</span>
-                            <p style={{ fontSize: '24px', color: '#374151' }}>Distribuidora</p>
-                        </div>
-                    </div>
+                {groupedProducts.flatMap(group => (
+                    group.products.map(p => (
+                        <PrintableProductCard key={p.id} product={p} category={group.category} />
+                    ))
                 ))}
             </div>
         );
@@ -309,32 +323,37 @@
 
                 printableElement.style.display = 'block';
 
-                const categorySections = printableElement.getElementsByClassName('printable-category-section');
+                const productSections = Array.from(printableElement.getElementsByClassName('printable-product'));
 
-                for (let i = 0; i < categorySections.length; i++) {
-                    const section = categorySections[i];
-                    const categoryName = section.dataset.categoryName || 'categoria';
-                    
-                    await new Promise(resolve => setTimeout(resolve, 100));
+                try {
+                    for (const section of productSections) {
+                        const productName = section.dataset.productName || 'produto';
+                        const categoryName = section.dataset.categoryName || 'categoria';
 
-                    const canvas = await html2canvas(section, {
-                        scale: 2,
-                        backgroundColor: '#f3f4f6',
-                        useCORS: true
-                    });
-                    
-                    const image = canvas.toDataURL("image/png", 1.0);
-                    
-                    const link = document.createElement('a');
-                    link.download = `catalogo-${categoryName.replace(/ /g, '_')}.png`;
-                    link.href = image;
-                    document.body.appendChild(link);
-                    link.click();
-                    document.body.removeChild(link);
+                        await new Promise(resolve => setTimeout(resolve, 300));
+
+                        const canvas = await html2canvas(section, {
+                            scale: 2,
+                            backgroundColor: '#f3f4f6',
+                            useCORS: true
+                        });
+
+                        const blob = await new Promise(resolve => canvas.toBlob(resolve, 'image/png', 1.0));
+                        const link = document.createElement('a');
+                        link.download = `catalogo-${categoryName.replace(/ /g, '_')}-${productName.replace(/ /g, '_')}.png`;
+                        link.href = URL.createObjectURL(blob);
+                        document.body.appendChild(link);
+                        link.click();
+                        document.body.removeChild(link);
+                        URL.revokeObjectURL(link.href);
+                    }
+                } catch (err) {
+                    console.error('Erro ao gerar imagens do catálogo:', err);
+                    alert('Não foi possível gerar as imagens do catálogo.');
+                } finally {
+                    printableElement.style.display = 'none';
+                    setIsGenerating(false);
                 }
-
-                printableElement.style.display = 'none';
-                setIsGenerating(false);
             };
 
             return (
@@ -374,7 +393,7 @@
             return (
                 <div className="bg-white rounded-3xl shadow-md overflow-hidden flex flex-col transition-all duration-300 hover:shadow-2xl hover:scale-105">
                     <div className="bg-gray-50 p-4 relative h-48 flex items-center justify-center">
-                        <img loading="lazy" src={product.imageUrl} alt={product.name} className="max-w-full max-h-full object-contain" />
+                        <img loading="lazy" src={product.imageUrl} alt={product.name} crossOrigin="anonymous" className="max-w-full max-h-full object-contain" />
                     </div>
                     <div className="p-4 flex-grow flex flex-col">
                         <h3 className="font-bold text-lg mb-3" style={{color: 'var(--brand-green)'}}>{product.name}</h3>
@@ -424,17 +443,17 @@
                         </p>
                         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
                             <div className="bg-white p-6 rounded-3xl shadow-lg text-center">
-                                <img src="https://group-ism.com/br/wp-content/uploads/2023/07/ism-9001.png" alt="[Imagem do selo ISO 9001]" className="h-28 mx-auto mb-4 rounded-xl"/>
+                                <img src="https://group-ism.com/br/wp-content/uploads/2023/07/ism-9001.png" alt="[Imagem do selo ISO 9001]" crossOrigin="anonymous" className="w-28 h-28 mx-auto mb-4 rounded-full object-cover"/>
                                 <h3 className="font-bold text-lg text-gray-800">ISO 9001</h3>
-                                <p className="text-sm text-gray-600">Norma internacional centrada na gestão da qualidade de um sistema efetivo, e melhoria da qualidade dos produtos e serviços.</p>
+                <p className="text-sm text-gray-600">Norma internacional centrada na gestão da qualidade de um sistema efetivo, e melhoria da qualidade dos produtos e serviços.</p>
                             </div>
                             <div className="bg-white p-6 rounded-3xl shadow-lg text-center">
-                                <img src="https://group-ism.com/br/wp-content/uploads/2023/07/ism-14001.png" alt="[Imagem do selo ISO 14001]" className="h-28 mx-auto mb-4 rounded-xl"/>
+                                <img src="https://group-ism.com/br/wp-content/uploads/2023/07/ism-14001.png" alt="[Imagem do selo ISO 14001]" crossOrigin="anonymous" className="w-28 h-28 mx-auto mb-4 rounded-full object-cover"/>
                                 <h3 className="font-bold text-lg text-gray-800">ISO 14001</h3>
                                 <p className="text-sm text-gray-600">Norma internacional focada no compromisso da organização com a proteção do meio ambiente por meio da gestão dos riscos ambientais.</p>
                             </div>
                             <div className="bg-white p-6 rounded-3xl shadow-lg text-center">
-                                <img src="https://group-ism.com/br/wp-content/uploads/2023/07/ism-45001-ES.png" alt="[Imagem do selo ISO 45001]" className="h-28 mx-auto mb-4 rounded-xl"/>
+                                <img src="https://group-ism.com/br/wp-content/uploads/2023/07/ism-45001-ES.png" alt="[Imagem do selo ISO 45001]" crossOrigin="anonymous" className="w-28 h-28 mx-auto mb-4 rounded-full object-cover"/>
                                 <h3 className="font-bold text-lg text-gray-800">ISO 45001</h3>
                                 <p className="text-sm text-gray-600">Norma internacional que proporciona as condições de trabalho seguras e saudáveis para prevenir os danos e deterioração da saúde.</p>
                             </div>
@@ -443,10 +462,11 @@
 
                     {/* Banner Section */}
                     <div className="mb-10 rounded-3xl shadow-lg overflow-hidden">
-                        <img 
-                            src="https://i.ibb.co/yFDqWmt0/IMG-0854.jpg" 
-                            alt="Banner promocional" 
+                        <img
+                            src="https://i.ibb.co/yFDqWmt0/IMG-0854.jpg"
+                            alt="Banner promocional"
                             className="w-full h-auto"
+                            crossOrigin="anonymous"
                             onError={(e) => { e.target.onerror = null; e.target.src='https://placehold.co/1200x300/1f2937/ffffff?text=Banner+Indisponível'; }}
                         />
                     </div>
@@ -496,10 +516,11 @@
                                                 NOVIDADE
                                             </div>
                                             <div className="rounded-3xl shadow-lg overflow-hidden mt-4">
-                                                <img 
-                                                    src="https://i.ibb.co/Vp9Pshb4/IMG-0863.jpg" 
-                                                    alt="Novas Cervejas" 
+                                                <img
+                                                    src="https://i.ibb.co/Vp9Pshb4/IMG-0863.jpg"
+                                                    alt="Novas Cervejas"
                                                     className="w-full h-auto"
+                                                    crossOrigin="anonymous"
                                                     onError={(e) => { e.target.onerror = null; e.target.src='https://placehold.co/1200x300/1f2937/ffffff?text=Banner+Indisponível'; }}
                                                 />
                                             </div>


### PR DESCRIPTION
## Summary
- Gera uma imagem 1080x1920 para cada produto com categoria e detalhes no canto superior direito
- Botão de download percorre cada item e salva como PNG individual
- Selos ISO exibidos como círculos perfeitos

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fc4597888333bf63e08709df3c4a